### PR TITLE
Add docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,16 @@ You can also ssh into your new Minion instances with `vagrant ssh minion-fronten
 Configuring Docker
 ------------------
 ```
-$ docker build -t 'mozilla/minion-backend'  -f Dockerfile-backend  .
-$ docker build -t 'mozilla/minion-frontend' -f Dockerfile-frontend .
+$ docker-compose create
 ```
 
 Running Docker
 --------------
 ```
-$ docker run -d --name 'minion-backend' 'mozilla/minion-backend'
-$ docker run -d -p 8080:8080 --name 'minion-frontend' \
-    --link minion-backend:minion-backend 'mozilla/minion-frontend'
+$ docker-compose up -d
 ```
 
 The Minion frontend should now be accessible over HTTP at the IP address of the system running Docker, on port 8080.
 
-You can also get a shell on your new Minion instances with `docker exec -i -t minion-frontend /bin/bash` and
-`docker exec -i -t minion-backend /bin/bash`.
+You can also get a shell on your new Minion instances with `docker-compose exec minion-frontend /bin/bash` and
+`docker-compose exec minion-backend /bin/bash`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@
 #
 
 version: '2.0'
-networks: {}
+networks:
+    minion_net:
+        driver: bridge
 services:
     minion-backend:
         build:
@@ -14,6 +16,8 @@ services:
             dockerfile: Dockerfile-backend
         image: mozilla/minion-backend
         container_name: minion-backend
+        networks:
+            - minion_net
         restart: always
     minion-frontend:
         build:
@@ -23,6 +27,8 @@ services:
         container_name: minion-frontend
         links:
             - minion-backend
+        networks:
+            - minion_net
         ports:
             - 8080:8080/tcp
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+#
+# Mozilla Minion Backend + Frontend
+#
+# Written by:
+#   Baptiste MOINE <contact@bmoine.fr>
+#
+
+version: '2.0'
+networks: {}
+services:
+    minion-backend:
+        build:
+            context: .
+            dockerfile: Dockerfile-backend
+        image: mozilla/minion-backend
+        container_name: minion-backend
+        restart: always
+    minion-frontend:
+        build:
+            context: .
+            dockerfile: Dockerfile-frontend
+        image: mozilla/minion-frontend
+        container_name: minion-frontend
+        links:
+            - minion-backend
+        ports:
+            - 8080:8080/tcp
+        restart: always
+volumes: {}
+


### PR DESCRIPTION
In order to make less complex the management of Docker multi-container application (e.g., minion-backend and minion-frontend) it can be interesting to use [Docker Compose](https://docs.docker.com/compose/overview/).